### PR TITLE
Make tags optional for Elements

### DIFF
--- a/Sources/SwiftOpenStreetMap/Models/OverpassResponse.swift
+++ b/Sources/SwiftOpenStreetMap/Models/OverpassResponse.swift
@@ -158,20 +158,20 @@ public enum Element: Equatable {
 
     fileprivate init?(json: JSON) {
         guard let jsonType = json["type"].string,
-            let id = json["id"].int,
-            let jsonTags = json["tags"].dictionary else {
+            let id = json["id"].int else {
                 return nil
         }
 
         var tags: [String: String] = [:]
-        for (key, jsonVal) in jsonTags {
-            if let val = jsonVal.string {
-                tags[key] = val
-            } else {
-                return nil
+        if let jsonTags = json["tags"].dictionary {
+            for (key, jsonVal) in jsonTags {
+                if let val = jsonVal.string {
+                    tags[key] = val
+                } else {
+                    return nil
+                }
             }
         }
-
 
         switch jsonType {
         case "node":

--- a/Tests/SwiftOpenStreetMapTests/Models/ModelsTest.swift
+++ b/Tests/SwiftOpenStreetMapTests/Models/ModelsTest.swift
@@ -41,6 +41,23 @@ class ModelsTest: QuickSpec {
 
                     expect(json.Element) == .node(element)
                 }
+                
+                it("works with type node without tags") {
+                    let json = JSON([
+                        "type": "node",
+                        "id": 34,
+                        "lat": 7.125,
+                        "lon": 8.75
+                        ])
+                    
+                    let element = Node(
+                        id: 34,
+                        location: Location(latitude: 7.125, longitude: 8.75),
+                        tags: [:]
+                    )
+                    
+                    expect(json.Element) == .node(element)
+                }
 
                 it("works with type way") {
                     /*
@@ -118,7 +135,7 @@ class ModelsTest: QuickSpec {
                         Node(
                             id: 23,
                             location: Location(latitude: 7.125, longitude: 8.75),
-                            tags: ["a": "tag", "other": "tag"]
+                            tags: [:]
                         ),
                     ]
 
@@ -138,7 +155,7 @@ class ModelsTest: QuickSpec {
                         Node(
                             id: 23,
                             location: Location(latitude: 7.125, longitude: 8.75),
-                            tags: ["a": "tag", "other": "tag"]
+                            tags: [:]
                         ),
                         Node(
                             id: 24,


### PR DESCRIPTION
It turns out basic nodes don't provide tags, therefore they won't get parsed making some ways to not contain their nodes. These changes amend this issue and it also changes the response's nodes and ways to be public rather than have them mixed together in elements.